### PR TITLE
Remove the Either from the parseRPMC type.

### DIFF
--- a/RPM/Parse.hs
+++ b/RPM/Parse.hs
@@ -111,10 +111,10 @@ parseRPM = do
         if remainder > 0 then fromIntegral $ 8 - remainder else 0
 
 -- Like parseRPM, but puts the resulting RPM into a Conduit.
-parseRPMC :: (Error e, MonadError e m) => Conduit C.ByteString m (Either e RPM)
+parseRPMC :: (Error e, MonadError e m) => Conduit C.ByteString m RPM
 parseRPMC =
     conduitParserEither parseRPM =$ consumer
  where
     consumer = awaitForever $ \case
         Left err       -> throwError (strMsg $ errorMessage err)
-        Right (_, rpm) -> yield $ Right rpm
+        Right (_, rpm) -> yield rpm

--- a/inspect.hs
+++ b/inspect.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-
 import Conduit(($$), (=$), awaitForever, stdinC)
 import Control.Monad.IO.Class(liftIO)
 import Data.Conduit(Consumer)
@@ -9,10 +7,8 @@ import Text.PrettyPrint.HughesPJClass(Pretty(pPrint))
 import RPM.Parse(parseRPMC)
 import RPM.Types(RPM)
 
-consumer :: Show e => Consumer (Either e RPM) IO ()
-consumer = awaitForever $ \case
-    Left err  -> liftIO $ print err
-    Right rpm -> liftIO $ putStrLn $ render $ pPrint rpm
+consumer :: Consumer RPM IO ()
+consumer = awaitForever (liftIO . putStrLn . render . pPrint)
 
 main :: IO ()
 main =


### PR DESCRIPTION
parseRPMC already uses throwError to indicate errors, so the only types
yielded through the conduit will be Right RPM. Remove the Either from
the type signature and just yield the RPM.
