### PR TITLE
Configure Makefile for usage in Jenkins by adding ci targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,10 @@ before_install:
   - travis_retry cabal update && cabal install hlint hpc-coveralls
 
 script:
-  - ~/.cabal/bin/hlint .
-  - cabal install --dependencies-only --enable-tests --force-reinstalls
-  - cabal configure --enable-tests --enable-coverage --ghc-option=-DTEST
-  - cabal build
-  - cabal test --show-details=always
+  - make ci
 
 after_success:
-  - ~/.cabal/bin/hpc-coveralls --display-report tests
+  - make ci_after_success
 
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,12 @@ hlint: sandbox
 	cabal exec hlint .
 
 tests: sandbox
-	cabal install --dependencies-only --enable-tests
-	cabal configure --enable-tests --enable-coverage
+	cabal install --dependencies-only --enable-tests --force-reinstalls
+	cabal configure --enable-tests --enable-coverage --ghc-option=-DTEST
 	cabal build
-	cabal test
+	cabal test --show-details=always
+
+ci: hlint tests
+
+ci_after_success:
+	hpc-coveralls --display-report tests

--- a/codec-rpm.cabal
+++ b/codec-rpm.cabal
@@ -64,7 +64,7 @@ test-suite tests
                         hspec-attoparsec >= 0.1.0.2 && < 0.2,
                         base >= 4.7 && < 5.0,
                         bytestring >= 0.10 && < 0.11,
-                        attoparsec >= 0.12.1.4 && < 0.13,
+                        attoparsec >= 0.12.1.4 && < 0.14,
                         codec-rpm,
                         text >= 1.2.2.2 && < 1.3
 


### PR DESCRIPTION
we'd like to switch to Jenkins for our testing purposes and by default Jenkins jobs are configured to execute `make ci'

Also make the Makefile and Travis targets execute the same commands!

@clumens, @dashea - do we want to continue using hackage.haskell.org or we want to switch using RPMs for the dependencies ? 