### PR TITLE
Workaround build failures in hscolour 1.24.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ sandbox:
 
 hlint: sandbox
 	[ -x .cabal-sandbox/bin/happy ] || cabal install happy
-	[ -x .cabal-sandbox/bin/hlint ] || cabal install hlint
+	[ -x .cabal-sandbox/bin/hlint ] || cabal install hscolour==1.24.2 hlint
 	cabal exec hlint .
 
 tests: sandbox


### PR DESCRIPTION
Install an older version b/c the latest upstream is broken.

Note: hscolour is a dependency of hlint. This only fails on Fedora 26 (very minimal install for our Jenkins slave). 