### PR TITLE
Fix the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ hlint: sandbox
 
 tests: sandbox
 	cabal install --dependencies-only --enable-tests --force-reinstalls
-	cabal configure --enable-tests --enable-coverage --ghc-option=-DTEST
+	cabal configure --enable-tests --enable-coverage
 	cabal build
 	cabal test --show-details=always
 

--- a/codec-rpm.cabal
+++ b/codec-rpm.cabal
@@ -56,7 +56,7 @@ library
 
 test-suite tests
     type:               exitcode-stdio-1.0
-    hs-source-dirs:     tests
+    hs-source-dirs:     ., tests
     main-is:            Spec.hs
     
     build-depends:      HUnit >= 1.6.0.0 && < 1.7,
@@ -65,9 +65,12 @@ test-suite tests
                         base >= 4.7 && < 5.0,
                         bytestring >= 0.10 && < 0.11,
                         attoparsec >= 0.12.1.4 && < 0.14,
-                        codec-rpm,
+                        attoparsec-binary >= 0.2 && < 0.3,
+                        parsec >= 3.1.11 && < 3.2,
+                        pretty >= 1.1.2.0,
                         text >= 1.2.2.2 && < 1.3
 
     default-language:   Haskell2010
 
     ghc-options:        -Wall
+    cpp-options:        -DTEST


### PR DESCRIPTION
To expose the private symbols via CPP, the tests need to recompile the
codec-rpm modules with -DTEST. Add the cpp flag to the .cabal file and
redo the tests section so that it recompiles the code to be tested
instead of using the compiled library.