### PR TITLE
Install hlint and hpc-coveralls at the same time as everything else.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,7 @@ sandbox:
 	[ -d .cabal-sandbox ] || cabal sandbox init && cabal update
 
 hlint: sandbox
-	[ -x .cabal-sandbox/bin/happy ] || cabal install happy
-	[ -x .cabal-sandbox/bin/hlint ] || cabal install hscolour==1.24.2 hlint
-	cabal exec hlint .
+	[ -x .cabal-sandbox/bin/hlint ] && cabal exec hlint .
 
 tests: sandbox
 	cabal install --dependencies-only --enable-tests --force-reinstalls
@@ -15,5 +13,4 @@ tests: sandbox
 ci: hlint tests
 
 ci_after_success:
-	[ -x .cabal-sandbox/bin/hpc-coveralls ] || cabal install hpc-coveralls
-	cabal exec hpc-coveralls --display-report tests
+	[ -x .cabal-sandbox/bin/hpc-coveralls ] && cabal exec -- hpc-coveralls --display-report tests

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ tests: sandbox
 	cabal build
 	cabal test --show-details=always
 
-ci: hlint tests
+ci: tests hlint
 
 ci_after_success:
 	[ -x .cabal-sandbox/bin/hpc-coveralls ] && cabal exec -- hpc-coveralls --display-report tests

--- a/codec-rpm.cabal
+++ b/codec-rpm.cabal
@@ -66,6 +66,8 @@ test-suite tests
                         bytestring >= 0.10 && < 0.11,
                         attoparsec >= 0.12.1.4 && < 0.14,
                         attoparsec-binary >= 0.2 && < 0.3,
+                        hlint,
+                        hpc-coveralls,
                         parsec >= 3.1.11 && < 3.2,
                         pretty >= 1.1.2.0,
                         text >= 1.2.2.0 && < 1.3


### PR DESCRIPTION
This turns them into build dependencies for the test-suite target.
Elsewhere, we are having a problem where hlint gets installed first,
populating the sandbox with versions of its dependencies that satisfy
hlint but may conflict with the library target.  Then when the library
is built, its dependencies may not be satisfiable given the earlier
choices made when installing hlint.

I have also removed happy as a requirement - nothing appears to use it.