### PR TITLE
Link to latest tarball for Jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ tests: sandbox
 dist: sandbox
 	cabal configure
 	cabal sdist
+	ln dist/codec-rpm-*.tar.gz dist/codec-rpm-latest.tar.gz
 
 ci: tests hlint
 


### PR DESCRIPTION
upload of artifacts is fine with wildcards but copyartifact
needs the exact name.