### PR TITLE
Update deps for ghc 9.2/GHC 9.4

### DIFF
--- a/Codec/RPM/Conduit.hs
+++ b/Codec/RPM/Conduit.hs
@@ -21,7 +21,7 @@ import           Control.Monad.Except(MonadError, throwError)
 import           Control.Monad.Trans.Resource(MonadResource)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as C
-import           Data.Conduit((.|), Conduit, awaitForever, yield)
+import           Data.Conduit((.|), ConduitT, awaitForever, yield)
 import           Data.Conduit.Attoparsec(ParseError, conduitParserEither)
 import           Data.Conduit.Lzma(decompress)
 import           Data.CPIO(Entry, readCPIO)
@@ -40,19 +40,19 @@ import Codec.RPM.Types(RPM(..))
 -- On success, the 'RPM' record will be passed down the conduit for futher processing or
 -- consumption.  On error, the rest of the conduit will be skipped and the 'ParseError' will
 -- be returned as the result to be dealt with.
-parseRPMC :: MonadError ParseError m => Conduit C.ByteString m RPM
+parseRPMC :: MonadError ParseError m => ConduitT C.ByteString RPM m ()
 parseRPMC =
     conduitParserEither parseRPM .| consumer
  where
     consumer = awaitForever $ either throwError (yield . snd)
 
 -- | Extract the package payload from an 'RPM', returning it in the conduit.
-payloadC :: Monad m => Conduit RPM m BS.ByteString
+payloadC :: Monad m => ConduitT RPM BS.ByteString m ()
 payloadC = awaitForever (yield . rpmArchive)
 
 -- | Extract the package payload from an 'RPM', decompress it, and return each element of
 -- the payload as a 'Data.CPIO.Entry'.
-payloadContentsC :: (MonadResource m, MonadThrow m) => Conduit RPM m Entry
+payloadContentsC :: (MonadResource m, MonadThrow m) => ConduitT RPM Entry m ()
 payloadContentsC = payloadC
                 .| decompress Nothing
                 .| readCPIO

--- a/Codec/RPM/Version.hs
+++ b/Codec/RPM/Version.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- |
 -- Module: Codec.RPM.Parse
 -- Copyright: (c) 2017 Red Hat, Inc.
@@ -23,7 +24,13 @@ module Codec.RPM.Version(
 
 import           Data.Char(digitToInt, isAsciiLower, isAsciiUpper, isDigit, isSpace)
 import           Data.Maybe(fromMaybe)
+
+#if MIN_VERSION_base(4,11,0) 
+import           Data.Semigroup ()
+#else
 import           Data.Monoid((<>))
+#endif
+
 import qualified Data.Ord as Ord
 import qualified Data.Text as T
 import           Data.Word(Word32)

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,10 @@
+packages: .
+
+-- cpio-conduit-0.7.2 on hackage has an incompatibility with newer versions of
+-- base16-bytestring. A PR was merged to fix this, but
+-- a new release was never cut to hackage.
+-- Remove this when version 0.7.3 is released to hackage.
+source-repository-package
+  type: git
+  location: https://github.com/da-x/cpio-conduit
+  tag: 30d92919e82c5033fffac7b34288f5a7fd28e9be

--- a/codec-rpm.cabal
+++ b/codec-rpm.cabal
@@ -1,5 +1,5 @@
 name:               codec-rpm
-version:            0.2.2
+version:            0.2.3
 synopsis:           A library for manipulating RPM files
 description:        This module provides a library for reading RPM files and converting them
                     into useful data structures.  There is currently no way to operate in
@@ -10,7 +10,7 @@ author:             Chris Lumens
 maintainer:         clumens@redhat.com
 license:            LGPL-2.1
 license-file:       LICENSE
-cabal-version:      >= 1.18
+cabal-version:      1.18
 build-type:         Simple
 
 extra-source-files: ChangeLog.md,
@@ -36,10 +36,10 @@ library
 
     other-modules:      Codec.RPM.Internal.Numbers
 
-    build-depends:      attoparsec >= 0.12.1.4 && < 0.14,
+    build-depends:      attoparsec >= 0.12.1.4 && < 0.15,
                         attoparsec-binary >= 0.2 && < 0.3,
                         base >= 4.7 && < 5.0,
-                        bytestring >= 0.10 && < 0.11,
+                        bytestring >= 0.10 && < 0.12,
                         conduit >= 1.2.8 && < 1.4,
                         conduit-extra >= 1.1.15 && < 1.4,
                         cpio-conduit >= 0.7.0 && < 0.8.0,
@@ -83,10 +83,10 @@ test-suite tests
                         Codec.RPM.VersionSpec
 
     build-depends:      HUnit >= 1.5.0.0 && < 1.7,
-                        hspec >= 2.4.4 && < 2.6,
+                        hspec >= 2.4.4 && < 2.11,
                         hspec-attoparsec >= 0.1.0.2 && < 0.2,
                         base >= 4.7 && < 5.0,
-                        bytestring >= 0.10 && < 0.11,
+                        bytestring >= 0.10 && < 0.12,
                         attoparsec >= 0.12.1.4 && < 0.14,
                         attoparsec-binary >= 0.2 && < 0.3,
                         parsec >= 3.1.11 && < 3.2,

--- a/codec-rpm.cabal
+++ b/codec-rpm.cabal
@@ -49,7 +49,7 @@ library
                         parsec >= 3.1.11 && < 3.2,
                         pretty >= 1.1.2.0,
                         resourcet >= 1.1.9 && < 1.3,
-                        text >= 1.2.2.0 && < 1.3
+                        text >= 1.2.2.0 && < 2.1
 
     default-language:   Haskell2010
 
@@ -93,7 +93,7 @@ test-suite tests
                         attoparsec-binary >= 0.2 && < 0.3,
                         parsec >= 3.1.11 && < 3.2,
                         pretty >= 1.1.2.0,
-                        text >= 1.2.2.0 && < 1.3
+                        text >= 1.2.2.0 && < 2.1
 
     default-language:   Haskell2010
 

--- a/codec-rpm.cabal
+++ b/codec-rpm.cabal
@@ -82,12 +82,14 @@ test-suite tests
                         Codec.RPM.Version,
                         Codec.RPM.VersionSpec
 
+    build-tool-depends: hspec-discover:hspec-discover >=2.10.0.0 && < 2.11
+
     build-depends:      HUnit >= 1.5.0.0 && < 1.7,
                         hspec >= 2.4.4 && < 2.11,
                         hspec-attoparsec >= 0.1.0.2 && < 0.2,
                         base >= 4.7 && < 5.0,
                         bytestring >= 0.10 && < 0.12,
-                        attoparsec >= 0.12.1.4 && < 0.14,
+                        attoparsec >= 0.12.1.4 && < 0.15,
                         attoparsec-binary >= 0.2 && < 0.3,
                         parsec >= 3.1.11 && < 3.2,
                         pretty >= 1.1.2.0,


### PR DESCRIPTION
This PR makes codec-rpm compile with both GHC 9.2 and GHC 9.4. Some other changes:

1. Newer versions of Conduit warn against using `Coduit` over `ConduitT`. I've edited the code to turn off those warnings. `ConduitT` is available since 2015's [0.2.0](https://hackage.haskell.org/package/conduit-0.2.0) which wouldn't compile with the current version of `codec-rpm` anyways because of base version constraints.
2. The `<>` function was made a class method of `Semigroup` in base > 4.11 and on newer version of base emits a warning about that if you try to import it via `Data.Monoid`. I've added a preprocessor directive to import it from the right place based on `base`'s version.
3. I added a `cabal.project`. The newer versions of `base16-bytestring` are incompatible with the versions of `cpio-conduit` available on hackage so I pull in the new version via a git sha.